### PR TITLE
Update ViewPagerIndicator.java

### DIFF
--- a/library_zhy_viewpagerIndicator/src/com/zhy/view/ViewPagerIndicator.java
+++ b/library_zhy_viewpagerIndicator/src/com/zhy/view/ViewPagerIndicator.java
@@ -184,7 +184,7 @@ public class ViewPagerIndicator extends LinearLayout
 
 		// 容器移动，在tab处于移动至最后一个时
 		if (position >= (mTabVisibleCount - 2) && offset > 0
-				&& getChildCount() > mTabVisibleCount)
+				&& getChildCount() > mTabVisibleCount && position != (getChildCount() - 2))
 		{
 
 			if (mTabVisibleCount != 1)


### PR DESCRIPTION
倒数第二个tab滑到最后一个tab时，tab依旧填充整个indicator
